### PR TITLE
Drop docsrs config item, not needed

### DIFF
--- a/rockfile/Cargo.toml
+++ b/rockfile/Cargo.toml
@@ -18,7 +18,3 @@ bytes = "1.4.0"
 anyhow = "1.0.69"
 clap = { version = "4.1.6", features = ["derive"] }
 crc = "3.0.1"
-
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/rockfile/src/lib.rs
+++ b/rockfile/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
 /// Rockchip boot file parsers

--- a/rockusb/Cargo.toml
+++ b/rockusb/Cargo.toml
@@ -31,10 +31,6 @@ nbd = "0.2.3"
 rockfile = { path = "../rockfile" }
 rusb = "0.9.1"
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-
 [[example]]
 name="rockusb"
 required-features = ["libusb"]


### PR DESCRIPTION
The docsrs config item trick can be used for supporting features that are in nightly rustdoc (as ran by docs.rs) but not in stable version (as will be used by most developers). These crates don't currently use some features so drop the cfg flag