### PR TITLE
Represent bootfile support chip as byte array

### DIFF
--- a/rockfile/examples/rockfile.rs
+++ b/rockfile/examples/rockfile.rs
@@ -19,8 +19,8 @@ fn parse_entry(header: RkBootHeaderEntry, name: &str, file: &mut File) -> Result
         file.read_exact(&mut entry)?;
         let entry = RkBootEntry::from_bytes(&entry);
         println!("== {} Entry  {} ==", name, i);
-        println!("{:?}", entry);
         println!("Name: {}", String::from_utf16(entry.name.as_slice())?);
+        println!("Raw: {:?}", entry);
 
         let mut data = Vec::new();
         data.resize(entry.data_size as usize, 0);
@@ -28,7 +28,7 @@ fn parse_entry(header: RkBootHeaderEntry, name: &str, file: &mut File) -> Result
         file.read_exact(&mut data)?;
 
         let crc = crc::Crc::<u16>::new(&crc::CRC_16_IBM_3740);
-        println!("CRC: {:x}", crc.checksum(&data));
+        println!("Data CRC: {:x}", crc.checksum(&data));
     }
 
     Ok(())
@@ -41,11 +41,11 @@ fn parse_boot(path: &Path) -> Result<()> {
     let header =
         RkBootHeader::from_bytes(&header).ok_or_else(|| anyhow!("Failed to parse header"))?;
 
-    println!("Header: {:?}", header);
+    println!("Raw Header: {:?}", header);
     println!(
-        "chip: {:x} - {}",
+        "chip: {:?} - {}",
         header.supported_chip,
-        String::from_utf8_lossy(&header.supported_chip.to_le_bytes())
+        String::from_utf8_lossy(&header.supported_chip)
     );
     parse_entry(header.entry_471, "0x471", &mut file)?;
     parse_entry(header.entry_472, "0x472", &mut file)?;

--- a/rockfile/src/boot.rs
+++ b/rockfile/src/boot.rs
@@ -116,7 +116,7 @@ pub struct RkBootHeader {
     pub version: u32,
     pub merge_version: u32,
     pub release: RkTime,
-    pub supported_chip: u32,
+    pub supported_chip: [u8; 4],
     pub entry_471: RkBootHeaderEntry,
     pub entry_472: RkBootHeaderEntry,
     pub entry_loader: RkBootHeaderEntry,
@@ -140,8 +140,7 @@ impl RkBootHeader {
         let release = RkTime::from_bytes(bytes[0..7].try_into().unwrap());
         bytes.advance(7);
 
-        let supported_chip = bytes.get_u32_le();
-
+        let supported_chip = bytes.get_u32().to_le_bytes();
         let entry_471 = RkBootHeaderEntry::from_bytes(bytes[0..6].try_into().unwrap());
         bytes.advance(6);
         let entry_472 = RkBootHeaderEntry::from_bytes(bytes[0..6].try_into().unwrap());


### PR DESCRIPTION
The support chip field in a bootfile isn't really a u32; It's a 4 byte ascii string encoding the chips model number, so represent it as such. In the data structure we keep it as a 4 byte array to avoid having to fail when there are non-ascii bytes in the field