### PR TITLE
protocol: fix endianness of transport_length field

### DIFF
--- a/rockusb/src/protocol.rs
+++ b/rockusb/src/protocol.rs
@@ -177,7 +177,12 @@ pub enum CommandBlockParseError {
     InvalidLength(usize),
 }
 
+/// Total size of a CBW command
 pub const COMMAND_BLOCK_BYTES: usize = 31;
+
+/// This structure represents a CBW command block according the USB Mass
+/// Storage class specification. It carries a SCSI command inside the 'CBWCB'
+/// bytes that is referred to in the code as 'command data block'.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandBlock {
     tag: u32,
@@ -293,7 +298,7 @@ impl CommandBlock {
     pub fn to_bytes(&self, mut bytes: &mut [u8]) -> usize {
         bytes.put_slice(b"USBC");
         bytes.put_u32(self.tag);
-        bytes.put_u32(self.transfer_length);
+        bytes.put_u32_le(self.transfer_length);
         bytes.put_u8(self.flags.into());
         bytes.put_u8(self.lun);
         bytes.put_u8(self.cdb_length);
@@ -315,7 +320,7 @@ impl CommandBlock {
             return Err(CommandBlockParseError::InvalidSignature(magic));
         }
         let tag = bytes.get_u32();
-        let transfer_length = bytes.get_u32();
+        let transfer_length = bytes.get_u32_le();
         let flags = Direction::try_from(bytes.get_u8())
             .map_err(|e| CommandBlockParseError::UnknownFlags(e.number))?;
         let lun = bytes.get_u8();


### PR DESCRIPTION
The USB device failed to respond and was triggering timeout errors due to the host sending an incorrect transport length. Changing endianness for this field fixed the issue.

According to the USB Mass Storage Class specification: "All CBW transfers shall be ordered with the LSB (byte 0) first (little endian)."

This error seems to be systematically present throughout the serialization of command blocks. Luckily, these incidents are immune to endianness changes in a way that does not affect the resulting behavior. This does not take away that the code in its current form is error-prone.

Be aware that '.put_uX(..)' will append values Big-endian. '.put_uX_le(..)' needs to be explicitly called for the data to be parsed with the correct endianness.