### PR TITLE
Target a specific clap to support older rustc

### DIFF
--- a/rockusb/Cargo.toml
+++ b/rockusb/Cargo.toml
@@ -25,7 +25,7 @@ rusb = { version = "0.9.1", optional = true }
 [dev-dependencies]
 anyhow = "1.0.69"
 bmap-parser = "0.1.0"
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { version = "=4.2", features = ["derive"] }
 clap-num = "1.0"
 flate2 = "1.0.25"
 nbd = "0.2.3"


### PR DESCRIPTION
Clap has a quite aggressive MSRV policy, so pin it to an older release series to support somewhat older rustc versions (1.64)