### PR TITLE
ci.yaml: bump toolchain version to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.64.0
+      - uses: dtolnay/rust-toolchain@1.70.0
       - run: cargo test --all-targets --all-features
 
   fmt:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.64.0
+      - uses: dtolnay/rust-toolchain@1.70.0
         with:
             components: rustfmt
       - run: cargo fmt --all --check
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.64.0
+      - uses: dtolnay/rust-toolchain@1.70.0
         with:
             components: clippy
       - run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
dependencies require version 1.70 to successfully compile. This change
    fixes the ci pipeline.