### PR TITLE
rockusb: Add progress bar for write bmap

### DIFF
--- a/rockusb/Cargo.toml
+++ b/rockusb/Cargo.toml
@@ -26,6 +26,7 @@ rusb = { version = "0.9.4", optional = true }
 nusb = { version = "0.1.10", optional = true }
 futures = { version = "0.3.31", optional = true }
 maybe-async-cfg = "0.2.5"
+indicatif = { version = "0.18.2", features = ["tokio"] }
 
 [dev-dependencies]
 anyhow = "1.0.69"


### PR DESCRIPTION
Added progress bar for write bmap using bmap-rs as reference.

```shell
Using bmap file: xxx.wic.bmap
⠓ [00:00:21] [#################################>-------------------------------------------] 815.79 MiB/1.82 GiB (31.6s)
```

Tested by:
```shell
# Async
cargo install --path rockusb --example rockusb --features=nusb

# Non-async
cargo install --path rockusb --example rockusb-libusb --features=libusb
```