### PR TITLE
rockusb: add read-flash command to dump entire flash to a file

### DIFF
--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -219,6 +219,42 @@ where
     }
 
     #[maybe_async_cfg::only_if(sync)]
+    pub fn read_flash(self, path: &Path) -> Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)?;
+        let mut io = self.device.into_io().await?;
+        println!(
+            "Reading {} MB ({} sectors)",
+            io.size() / (1024 * 1024),
+            io.size() / 512,
+        );
+        std::io::copy(&mut io, &mut file)?;
+        Ok(())
+    }
+
+    #[maybe_async_cfg::only_if(async)]
+    pub async fn read_flash(self, path: &Path) -> Result<()> {
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .await?;
+        let io = self.device.into_io().await?;
+        println!(
+            "Reading {} MB ({} sectors)",
+            io.size() / (1024 * 1024),
+            io.size() / 512,
+        );
+        let mut io = io.compat();
+        tokio::io::copy(&mut io, &mut file).await?;
+        Ok(())
+    }
+
+    #[maybe_async_cfg::only_if(sync)]
     pub fn write_file(self, offset: u32, path: &Path) -> Result<()> {
         let mut file = File::open(path)?;
         let mut io = self.device.into_io().await?;
@@ -389,6 +425,10 @@ pub enum Command {
     WriteBmap {
         path: PathBuf,
     },
+    /// Read the device's entire flash to a file
+    ReadFlash {
+        path: PathBuf,
+    },
     ChipInfo,
     FlashId,
     FlashInfo,
@@ -433,6 +473,7 @@ impl Command {
             } => device.write_lba(offset, length, &path).await,
             Command::WriteFile { offset, path } => device.write_file(offset, &path).await,
             Command::WriteBmap { path } => device.write_bmap(&path).await,
+            Command::ReadFlash { path } => device.read_flash(&path).await,
             Command::ChipInfo => device.read_chip_info().await,
             Command::FlashId => device.read_flash_id().await,
             Command::FlashInfo => device.read_flash_info().await,

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -245,6 +245,42 @@ where
     }
 
     #[maybe_async_cfg::only_if(sync)]
+    pub fn read_flash(self, path: &Path) -> Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)?;
+        let mut io = self.device.into_io().await?;
+        println!(
+            "Reading {} MB ({} sectors)",
+            io.size() / (1024 * 1024),
+            io.size() / 512,
+        );
+        std::io::copy(&mut io, &mut file)?;
+        Ok(())
+    }
+
+    #[maybe_async_cfg::only_if(async)]
+    pub async fn read_flash(self, path: &Path) -> Result<()> {
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .await?;
+        let io = self.device.into_io().await?;
+        println!(
+            "Reading {} MB ({} sectors)",
+            io.size() / (1024 * 1024),
+            io.size() / 512,
+        );
+        let mut io = io.compat();
+        tokio::io::copy(&mut io, &mut file).await?;
+        Ok(())
+    }
+
+    #[maybe_async_cfg::only_if(sync)]
     pub fn write_file(self, offset: u32, path: &Path) -> Result<()> {
         let mut file = File::open(path)?;
         let mut io = self.device.into_io().await?;
@@ -419,6 +455,9 @@ pub enum Command {
     WriteBmap {
         path: PathBuf,
     },
+    ReadFlash {
+        path: PathBuf,
+    },
     #[command(alias = "rci")]
     ChipInfo,
     #[command(alias = "rid")]
@@ -476,6 +515,7 @@ impl Command {
             } => device.write_lba(offset, length, &path).await,
             Command::WriteFile { offset, path } => device.write_file(offset, &path).await,
             Command::WriteBmap { path } => device.write_bmap(&path).await,
+            Command::ReadFlash { path } => device.read_flash(&path).await,
             Command::ChipInfo => device.read_chip_info().await,
             Command::FlashId => device.read_flash_id().await,
             Command::FlashInfo => device.read_flash_info().await,


### PR DESCRIPTION
Read the device's full flash contents to a file, printing the flash size before starting.

Fixes: #26

NOTE: This is a draft as it is currently completely untested as I don't have a rockchip device to hand now. Testing welcome !