### PR TITLE
feat: rockusb: add {get, switch} storage support

### DIFF
--- a/rockusb/Cargo.toml
+++ b/rockusb/Cargo.toml
@@ -21,6 +21,7 @@ bytes = "1.4.0"
 crc = "3.0.1"
 fastrand = "2"
 num_enum = "0.7"
+strum = { version = "0.27", features = ["derive"] }
 thiserror = "2.0.7"
 rusb = { version = "0.9.4", optional = true }
 nusb = { version = "0.1.10", optional = true }

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -197,7 +197,7 @@ where
         self.device.switch_storage(index).await?;
         // Rockchip protocol does not provide a way to get return code from
         // the "rkusb_do_switch_storage" function, so we can only check again
-        let new_index = self.device.get_storage().await?;
+        let new_index = self.device.storage().await?;
         if new_index == index {
             println!("Switched storage to {}", index);
         } else {
@@ -209,8 +209,8 @@ where
         Ok(())
     }
 
-    pub async fn get_storage(&mut self) -> Result<()> {
-        let media = self.device.get_storage().await?;
+    pub async fn storage(&mut self) -> Result<()> {
+        let media = self.device.storage().await?;
         println!("Storage media: {}", media);
         Ok(())
     }
@@ -440,7 +440,7 @@ pub enum Command {
         storage: StorageIndex,
     },
     /// Query the current storage type
-    GetStorage,
+    Storage,
 }
 
 impl Command {
@@ -483,7 +483,7 @@ impl Command {
             Command::Capability => device.read_capability().await,
             Command::ResetDevice { opcode } => device.reset_device(opcode).await,
             Command::SwitchStorage { storage } => device.switch_storage(storage).await,
-            Command::GetStorage => device.get_storage().await,
+            Command::Storage => device.storage().await,
         }
     }
 }

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::{Result, anyhow, ensure};
 use bmap_parser::Bmap;
-use clap::builder::TypedValueParser as _;
+use clap::builder::TypedValueParser;
 use clap_num::maybe_hex;
 use flate2::read::GzDecoder;
 use rockfile::boot::{
@@ -489,13 +489,50 @@ impl Command {
 }
 
 fn storage_parser() -> impl clap::builder::TypedValueParser<Value = StorageIndex> {
-    use strum::VariantArray as _;
-    clap::builder::PossibleValuesParser::new(
-        StorageIndex::VARIANTS
-            .iter()
-            .map(|v| -> &'static str { v.into() }),
-    )
-    .map(|s: String| s.parse::<StorageIndex>().unwrap())
+    StorageIndexParser
+}
+
+#[derive(Clone)]
+struct StorageIndexParser;
+
+impl clap::builder::TypedValueParser for StorageIndexParser {
+    type Value = StorageIndex;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<StorageIndex, clap::Error> {
+        let s = value.to_string_lossy();
+        if let Ok(idx) = s.parse::<StorageIndex>() {
+            return Ok(idx);
+        }
+        if let Ok(v) = s.parse::<u8>() {
+            return Ok(StorageIndex::from(v));
+        }
+        let mut err = clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd);
+        if let Some(arg) = arg {
+            err.insert(
+                clap::error::ContextKind::InvalidArg,
+                clap::error::ContextValue::String(arg.to_string()),
+            );
+        }
+        err.insert(
+            clap::error::ContextKind::InvalidValue,
+            clap::error::ContextValue::String(s.into_owned()),
+        );
+        Err(err)
+    }
+
+    fn possible_values(
+        &self,
+    ) -> Option<Box<dyn Iterator<Item = clap::builder::PossibleValue> + '_>> {
+        Some(Box::new(StorageIndex::VARIANTS.iter().map(|v| {
+            let name: &'static str = v.into();
+            clap::builder::PossibleValue::new(name)
+        })))
+    }
 }
 
 fn reset_parser() -> impl clap::builder::TypedValueParser<Value = ResetOpcode> {

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::{Result, anyhow, ensure};
 use bmap_parser::Bmap;
-use clap::{Arg, ValueEnum};
+use clap::{ValueEnum, builder::TypedValueParser as _};
 use clap_num::maybe_hex;
 use flate2::read::GzDecoder;
 use rockfile::boot::{
@@ -193,19 +193,17 @@ where
         Ok(())
     }
 
-    pub async fn switch_storage(&mut self, index: ArgStorageIndex) -> Result<()> {
-        let index_device = StorageIndex::from(index);
-        self.device.switch_storage(index_device).await?;
+    pub async fn switch_storage(&mut self, index: StorageIndex) -> Result<()> {
+        self.device.switch_storage(index).await?;
         // Rockchip protocol does not provide a way to get return code from
         // the "rkusb_do_switch_storage" function, so we can only check again
         let new_index = self.device.get_storage().await?;
-        if new_index == index_device {
+        if new_index == index {
             println!("Switched storage to {}", index);
         } else {
             println!(
                 "Failed to switch storage to {}, current storage is {}",
-                index,
-                ArgStorageIndex::from(new_index)
+                index, new_index
             );
         }
         Ok(())
@@ -213,8 +211,7 @@ where
 
     pub async fn get_storage(&mut self) -> Result<()> {
         let media = self.device.get_storage().await?;
-        let media_clap = ArgStorageIndex::from(media);
-        println!("Storage media: {}", media_clap);
+        println!("Storage media: {}", media);
         Ok(())
     }
 
@@ -439,8 +436,8 @@ pub enum Command {
     },
     /// Switch to a different storage device
     SwitchStorage {
-        #[clap(value_enum)]
-        storage: ArgStorageIndex,
+        #[arg(value_parser = storage_parser())]
+        storage: StorageIndex,
     },
     /// Query the current storage type
     GetStorage,
@@ -491,6 +488,16 @@ impl Command {
     }
 }
 
+fn storage_parser() -> impl clap::builder::TypedValueParser<Value = StorageIndex> {
+    use strum::VariantArray as _;
+    clap::builder::PossibleValuesParser::new(
+        StorageIndex::VARIANTS
+            .iter()
+            .map(|v| -> &'static str { v.into() }),
+    )
+    .map(|s: String| s.parse::<StorageIndex>().unwrap())
+}
+
 #[derive(ValueEnum, Clone, Debug)]
 pub enum ArgResetOpcode {
     /// Reset
@@ -515,51 +522,6 @@ impl From<ArgResetOpcode> for ResetOpcode {
             ArgResetOpcode::Maskrom => ResetOpcode::Maskrom,
             ArgResetOpcode::Disconnect => ResetOpcode::Disconnect,
         }
-    }
-}
-
-#[derive(ValueEnum, Clone, Debug, Copy)]
-pub enum ArgStorageIndex {
-    Emmc,
-    Sd,
-    Nand,
-    SpiNand,
-    SpiNor,
-    Sata,
-    Pcie,
-}
-
-impl From<ArgStorageIndex> for StorageIndex {
-    fn from(arg: ArgStorageIndex) -> StorageIndex {
-        match arg {
-            ArgStorageIndex::Emmc => StorageIndex::Emmc,
-            ArgStorageIndex::Sd => StorageIndex::Sd,
-            ArgStorageIndex::Nand => StorageIndex::MtdBlkNand,
-            ArgStorageIndex::SpiNand => StorageIndex::MtdBlkSpiNand,
-            ArgStorageIndex::SpiNor => StorageIndex::MtdBlkSpiNor,
-            ArgStorageIndex::Sata => StorageIndex::Sata,
-            ArgStorageIndex::Pcie => StorageIndex::Pcie,
-        }
-    }
-}
-
-impl From<StorageIndex> for ArgStorageIndex {
-    fn from(index: StorageIndex) -> ArgStorageIndex {
-        match index {
-            StorageIndex::Emmc => ArgStorageIndex::Emmc,
-            StorageIndex::Sd => ArgStorageIndex::Sd,
-            StorageIndex::MtdBlkNand => ArgStorageIndex::Nand,
-            StorageIndex::MtdBlkSpiNand => ArgStorageIndex::SpiNand,
-            StorageIndex::MtdBlkSpiNor => ArgStorageIndex::SpiNor,
-            StorageIndex::Sata => ArgStorageIndex::Sata,
-            StorageIndex::Pcie => ArgStorageIndex::Pcie,
-        }
-    }
-}
-
-impl std::fmt::Display for ArgStorageIndex {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_possible_value().unwrap().get_name())
     }
 }
 

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::{Result, anyhow, ensure};
 use bmap_parser::Bmap;
-use clap::{ValueEnum, builder::TypedValueParser as _};
+use clap::builder::TypedValueParser as _;
 use clap_num::maybe_hex;
 use flate2::read::GzDecoder;
 use rockfile::boot::{
@@ -431,8 +431,8 @@ pub enum Command {
     EraseFlash,
     #[command(alias = "rd")]
     ResetDevice {
-        #[clap(value_enum, default_value_t=ArgResetOpcode::Reset)]
-        opcode: ArgResetOpcode,
+        #[arg(value_parser = reset_parser(), default_value_t = ResetOpcode::Reset)]
+        opcode: ResetOpcode,
     },
     /// Switch to a different storage device
     SwitchStorage {
@@ -481,7 +481,7 @@ impl Command {
             Command::FlashInfo => device.read_flash_info().await,
             Command::EraseFlash => device.erase_flash().await,
             Command::Capability => device.read_capability().await,
-            Command::ResetDevice { opcode } => device.reset_device(opcode.into()).await,
+            Command::ResetDevice { opcode } => device.reset_device(opcode).await,
             Command::SwitchStorage { storage } => device.switch_storage(storage).await,
             Command::GetStorage => device.get_storage().await,
         }
@@ -498,31 +498,14 @@ fn storage_parser() -> impl clap::builder::TypedValueParser<Value = StorageIndex
     .map(|s: String| s.parse::<StorageIndex>().unwrap())
 }
 
-#[derive(ValueEnum, Clone, Debug)]
-pub enum ArgResetOpcode {
-    /// Reset
-    Reset,
-    /// Reset to USB mass-storage device class
-    #[allow(clippy::upper_case_acronyms)]
-    MSC,
-    /// Powers the SOC off
-    PowerOff,
-    /// Reset to maskrom mode
-    Maskrom,
-    /// Disconnect from USB
-    Disconnect,
-}
-
-impl From<ArgResetOpcode> for ResetOpcode {
-    fn from(arg: ArgResetOpcode) -> ResetOpcode {
-        match arg {
-            ArgResetOpcode::Reset => ResetOpcode::Reset,
-            ArgResetOpcode::MSC => ResetOpcode::MSC,
-            ArgResetOpcode::PowerOff => ResetOpcode::PowerOff,
-            ArgResetOpcode::Maskrom => ResetOpcode::Maskrom,
-            ArgResetOpcode::Disconnect => ResetOpcode::Disconnect,
-        }
-    }
+fn reset_parser() -> impl clap::builder::TypedValueParser<Value = ResetOpcode> {
+    use strum::VariantArray as _;
+    clap::builder::PossibleValuesParser::new(
+        ResetOpcode::VARIANTS
+            .iter()
+            .map(|v| -> &'static str { v.into() }),
+    )
+    .map(|s: String| s.parse::<ResetOpcode>().unwrap())
 }
 
 #[derive(Debug, Clone)]

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::{Result, anyhow, ensure};
 use bmap_parser::Bmap;
-use clap::ValueEnum;
+use clap::{Arg, ValueEnum};
 use clap_num::maybe_hex;
 use flate2::read::GzDecoder;
 use rockfile::boot::{
@@ -17,7 +17,7 @@ use rockfile::boot::{
 };
 use rockusb::{
     device::{Device, Transport},
-    protocol::ResetOpcode,
+    protocol::{ResetOpcode, StorageIndex},
 };
 
 #[cfg(feature = "async")]
@@ -130,6 +130,10 @@ where
             println!(" - New IDB");
         }
 
+        if capability.switch_storage() {
+            println!(" - Switch storage");
+        }
+
         Ok(())
     }
 
@@ -186,6 +190,31 @@ where
 
     pub async fn reset_device(&mut self, opcode: ResetOpcode) -> Result<()> {
         self.device.reset_device(opcode).await?;
+        Ok(())
+    }
+
+    pub async fn switch_storage(&mut self, index: ArgStorageIndex) -> Result<()> {
+        let index_device = StorageIndex::from(index);
+        self.device.switch_storage(index_device).await?;
+        // Rockchip protocol does not provide a way to get return code from
+        // the "rkusb_do_switch_storage" function, so we can only check again
+        let new_index = self.device.get_storage().await?;
+        if new_index == index_device {
+            println!("Switched storage to {}", index);
+        } else {
+            println!(
+                "Failed to switch storage to {}, current storage is {}",
+                index,
+                ArgStorageIndex::from(new_index)
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn get_storage(&mut self) -> Result<()> {
+        let media = self.device.get_storage().await?;
+        let media_clap = ArgStorageIndex::from(media);
+        println!("Storage media: {}", media_clap);
         Ok(())
     }
 
@@ -408,6 +437,13 @@ pub enum Command {
         #[clap(value_enum, default_value_t=ArgResetOpcode::Reset)]
         opcode: ArgResetOpcode,
     },
+    /// Switch to a different storage device
+    SwitchStorage {
+        #[clap(value_enum)]
+        storage: ArgStorageIndex,
+    },
+    /// Query the current storage type
+    GetStorage,
 }
 
 impl Command {
@@ -449,6 +485,8 @@ impl Command {
             Command::EraseFlash => device.erase_flash().await,
             Command::Capability => device.read_capability().await,
             Command::ResetDevice { opcode } => device.reset_device(opcode.into()).await,
+            Command::SwitchStorage { storage } => device.switch_storage(storage).await,
+            Command::GetStorage => device.get_storage().await,
         }
     }
 }
@@ -477,6 +515,51 @@ impl From<ArgResetOpcode> for ResetOpcode {
             ArgResetOpcode::Maskrom => ResetOpcode::Maskrom,
             ArgResetOpcode::Disconnect => ResetOpcode::Disconnect,
         }
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug, Copy)]
+pub enum ArgStorageIndex {
+    Emmc,
+    Sd,
+    Nand,
+    SpiNand,
+    SpiNor,
+    Sata,
+    Pcie,
+}
+
+impl From<ArgStorageIndex> for StorageIndex {
+    fn from(arg: ArgStorageIndex) -> StorageIndex {
+        match arg {
+            ArgStorageIndex::Emmc => StorageIndex::Emmc,
+            ArgStorageIndex::Sd => StorageIndex::Sd,
+            ArgStorageIndex::Nand => StorageIndex::MtdBlkNand,
+            ArgStorageIndex::SpiNand => StorageIndex::MtdBlkSpiNand,
+            ArgStorageIndex::SpiNor => StorageIndex::MtdBlkSpiNor,
+            ArgStorageIndex::Sata => StorageIndex::Sata,
+            ArgStorageIndex::Pcie => StorageIndex::Pcie,
+        }
+    }
+}
+
+impl From<StorageIndex> for ArgStorageIndex {
+    fn from(index: StorageIndex) -> ArgStorageIndex {
+        match index {
+            StorageIndex::Emmc => ArgStorageIndex::Emmc,
+            StorageIndex::Sd => ArgStorageIndex::Sd,
+            StorageIndex::MtdBlkNand => ArgStorageIndex::Nand,
+            StorageIndex::MtdBlkSpiNand => ArgStorageIndex::SpiNand,
+            StorageIndex::MtdBlkSpiNor => ArgStorageIndex::SpiNor,
+            StorageIndex::Sata => ArgStorageIndex::Sata,
+            StorageIndex::Pcie => ArgStorageIndex::Pcie,
+        }
+    }
+}
+
+impl std::fmt::Display for ArgStorageIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_possible_value().unwrap().get_name())
     }
 }
 

--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -165,9 +165,9 @@ where
     }
 
     /// Query the current storage media type
-    pub async fn get_storage(&mut self) -> DeviceResult<StorageIndex, T> {
+    pub async fn storage(&mut self) -> DeviceResult<StorageIndex, T> {
         self.transport
-            .handle_operation(crate::operation::get_storage())
+            .handle_operation(crate::operation::storage())
             .await
     }
 

--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     operation::OperationSteps,
-    protocol::{Capability, ChipInfo, FlashId, FlashInfo, ResetOpcode, SECTOR_SIZE},
+    protocol::{Capability, ChipInfo, FlashId, FlashInfo, ResetOpcode, SECTOR_SIZE, StorageIndex},
 };
 
 #[cfg(feature = "async")]
@@ -154,6 +154,20 @@ where
     pub async fn reset_device(&mut self, opcode: ResetOpcode) -> DeviceResult<(), T> {
         self.transport
             .handle_operation(crate::operation::reset_device(opcode))
+            .await
+    }
+
+    /// Switch to a different storage device
+    pub async fn switch_storage(&mut self, index: StorageIndex) -> DeviceResult<(), T> {
+        self.transport
+            .handle_operation(crate::operation::switch_storage(index))
+            .await
+    }
+
+    /// Query the current storage media type
+    pub async fn get_storage(&mut self) -> DeviceResult<StorageIndex, T> {
+        self.transport
+            .handle_operation(crate::operation::get_storage())
             .await
     }
 

--- a/rockusb/src/operation.rs
+++ b/rockusb/src/operation.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::protocol::{
     self, Capability, ChipInfo, CommandBlock, CommandStatus, CommandStatusParseError, Direction,
-    FlashId, FlashInfo, ResetOpcode,
+    FlashId, FlashInfo, ResetOpcode, StorageIndex,
 };
 use thiserror::Error;
 
@@ -380,6 +380,35 @@ impl FromOperation for () {
 /// Create operation to reset the SoC
 pub fn reset_device(opcode: ResetOpcode) -> UsbOperation<'static, ()> {
     UsbOperation::new(CommandBlock::reset_device(opcode))
+}
+
+impl FromOperation for StorageIndex {
+    fn from_operation(io: &[u8], _status: &CommandStatus) -> Result<Self, UsbOperationError>
+    where
+        Self: Sized,
+    {
+        let data: [u8; 4] = io
+            .try_into()
+            .map_err(|_e| UsbOperationError::ReplyParseFailure)?;
+        let data = u32::from_le_bytes(data);
+        // index is one-hot, bit index corresponds to storage index
+        if data.count_ones() != 1 {
+            return Err(UsbOperationError::ReplyParseFailure);
+        }
+        let index = StorageIndex::try_from(data.trailing_zeros() as u8)
+            .map_err(|_e| UsbOperationError::ReplyParseFailure)?;
+        Ok(index)
+    }
+}
+
+/// Create operation to switch the active storage device
+pub fn switch_storage(index: StorageIndex) -> UsbOperation<'static, ()> {
+    UsbOperation::new(CommandBlock::switch_storage(index))
+}
+
+/// Create operation to query the current storage media type
+pub fn get_storage() -> UsbOperation<'static, StorageIndex> {
+    UsbOperation::new(CommandBlock::get_storage())
 }
 
 /// Bytes transferred

--- a/rockusb/src/operation.rs
+++ b/rockusb/src/operation.rs
@@ -395,8 +395,7 @@ impl FromOperation for StorageIndex {
         if data.count_ones() != 1 {
             return Err(UsbOperationError::ReplyParseFailure);
         }
-        let index = StorageIndex::try_from(data.trailing_zeros() as u8)
-            .map_err(|_e| UsbOperationError::ReplyParseFailure)?;
+        let index = StorageIndex::from(data.trailing_zeros() as u8);
         Ok(index)
     }
 }

--- a/rockusb/src/operation.rs
+++ b/rockusb/src/operation.rs
@@ -400,14 +400,14 @@ impl FromOperation for StorageIndex {
     }
 }
 
-/// Create operation to switch the active storage device
+/// Create operation to switch the active storage media
 pub fn switch_storage(index: StorageIndex) -> UsbOperation<'static, ()> {
     UsbOperation::new(CommandBlock::switch_storage(index))
 }
 
 /// Create operation to query the current storage media type
-pub fn get_storage() -> UsbOperation<'static, StorageIndex> {
-    UsbOperation::new(CommandBlock::get_storage())
+pub fn storage() -> UsbOperation<'static, StorageIndex> {
+    UsbOperation::new(CommandBlock::storage())
 }
 
 /// Bytes transferred

--- a/rockusb/src/protocol.rs
+++ b/rockusb/src/protocol.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use bytes::{Buf, BufMut};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use strum::{Display, EnumString, IntoStaticStr, VariantArray};
 
 pub const SECTOR_SIZE: u64 = 512;
 
@@ -232,12 +233,28 @@ impl Capability {
 
 /// Index used for switch_storage command (bit position in BOOT_TYPE bitmask)
 #[repr(u8)]
-#[derive(Debug, Eq, PartialEq, Clone, Copy, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    Clone,
+    Copy,
+    IntoPrimitive,
+    TryFromPrimitive,
+    Display,
+    EnumString,
+    IntoStaticStr,
+    VariantArray,
+)]
+#[strum(serialize_all = "lowercase")]
 pub enum StorageIndex {
     Emmc = 1,
     Sd = 2,
+    #[strum(to_string = "nand")]
     MtdBlkNand = 7,
+    #[strum(to_string = "spi-nand")]
     MtdBlkSpiNand = 8,
+    #[strum(to_string = "spi-nor")]
     MtdBlkSpiNor = 9,
     Sata = 10,
     Pcie = 11,

--- a/rockusb/src/protocol.rs
+++ b/rockusb/src/protocol.rs
@@ -47,11 +47,25 @@ pub enum CommandCode {
 }
 
 #[repr(u8)]
-#[derive(Debug, Eq, PartialEq, Clone, Copy, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    Clone,
+    Copy,
+    IntoPrimitive,
+    TryFromPrimitive,
+    Display,
+    EnumString,
+    IntoStaticStr,
+    VariantArray,
+)]
+#[strum(serialize_all = "kebab-case")]
 pub enum ResetOpcode {
     /// Reset
     Reset = 0,
     /// Reset to USB mass-storage device class
+    #[strum(to_string = "msc")]
     MSC,
     /// Powers the SOC off
     PowerOff,

--- a/rockusb/src/protocol.rs
+++ b/rockusb/src/protocol.rs
@@ -39,6 +39,8 @@ pub enum CommandCode {
     WriteNewEfuse = 0x23,
     ReadNewEfuse = 0x24,
     EraseLBA = 0x25,
+    SwitchStorage = 0x2A,
+    GetStorageMedia = 0x2B,
     ReadCapability = 0xAA,
     DeviceReset = 0xFF,
 }
@@ -176,6 +178,7 @@ impl Capability {
     const READ_IDB_CONFIG: [u8; 2] = [0, 0x40];
     const READ_SECURE_MODE: [u8; 2] = [0, 0x80];
     const NEW_IDB: [u8; 2] = [1, 0x01];
+    const SWITCH_STORAGE: [u8; 2] = [1, 0x02];
 
     pub fn from_bytes(data: [u8; 8]) -> Self {
         Capability(data)
@@ -213,6 +216,10 @@ impl Capability {
         self.check_flag(Self::NEW_IDB)
     }
 
+    pub fn switch_storage(&self) -> bool {
+        self.check_flag(Self::SWITCH_STORAGE)
+    }
+
     pub fn inner(&self) -> &[u8] {
         &self.0
     }
@@ -221,6 +228,19 @@ impl Capability {
         let [idx, bit] = flag;
         self.0[idx as usize] & bit == bit
     }
+}
+
+/// Index used for switch_storage command (bit position in BOOT_TYPE bitmask)
+#[repr(u8)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, IntoPrimitive, TryFromPrimitive)]
+pub enum StorageIndex {
+    Emmc = 1,
+    Sd = 2,
+    MtdBlkNand = 7,
+    MtdBlkSpiNand = 8,
+    MtdBlkSpiNor = 9,
+    Sata = 10,
+    Pcie = 11,
 }
 
 #[derive(Debug, thiserror::Error, Clone)]
@@ -413,6 +433,34 @@ impl CommandBlock {
     /// count, or payload length encoded in the CBW/CDB.
     pub fn cd_length(&self) -> u16 {
         self.cd_length
+    }
+
+    pub fn switch_storage(index: StorageIndex) -> CommandBlock {
+        CommandBlock {
+            tag: fastrand::u32(..),
+            transfer_length: 0,
+            flags: Direction::Out,
+            lun: 0,
+            cdb_length: 0x6,
+            cd_code: CommandCode::SwitchStorage,
+            cd_opcode: index.into(),
+            cd_address: 0,
+            cd_length: 0x0,
+        }
+    }
+
+    pub fn get_storage() -> CommandBlock {
+        CommandBlock {
+            tag: fastrand::u32(..),
+            transfer_length: 4,
+            flags: Direction::In,
+            lun: 0,
+            cdb_length: 0x6,
+            cd_code: CommandCode::GetStorageMedia,
+            cd_opcode: 0,
+            cd_address: 0,
+            cd_length: 0x0,
+        }
     }
 
     pub fn tag(&self) -> u32 {

--- a/rockusb/src/protocol.rs
+++ b/rockusb/src/protocol.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use bytes::{Buf, BufMut};
-use num_enum::{IntoPrimitive, TryFromPrimitive};
+use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
 use strum::{Display, EnumString, IntoStaticStr, VariantArray};
 
 pub const SECTOR_SIZE: u64 = 512;
@@ -245,33 +245,79 @@ impl Capability {
     }
 }
 
-/// Index used for switch_storage command (bit position in BOOT_TYPE bitmask)
+/// Index used for switch_storage command (bit position in BOOT_TYPE bitmask).
+///
+/// Named variants map to the bit positions defined in the Rockchip u-boot
+/// `BOOT_TYPE_*` constants.  `Unknown` carries any value not (yet) recognised
+/// by this library so that callers are never forced to treat an unrecognised
+/// device as an error.
+#[non_exhaustive]
 #[repr(u8)]
 #[derive(
-    Debug,
-    Eq,
-    PartialEq,
-    Clone,
-    Copy,
-    IntoPrimitive,
-    TryFromPrimitive,
-    Display,
-    EnumString,
-    IntoStaticStr,
-    VariantArray,
+    Debug, Eq, PartialEq, Clone, Copy, FromPrimitive, EnumString, IntoStaticStr, IntoPrimitive,
 )]
-#[strum(serialize_all = "lowercase")]
+#[strum(serialize_all = "kebab-case")]
 pub enum StorageIndex {
+    /// BOOT_TYPE_NAND (bit 0)
+    Nand = 0,
+    /// BOOT_TYPE_EMMC (bit 1)
     Emmc = 1,
-    Sd = 2,
-    #[strum(to_string = "nand")]
+    /// BOOT_TYPE_SD0 (bit 2)
+    #[strum(to_string = "sd0")]
+    Sd0 = 2,
+    /// BOOT_TYPE_SD1 (bit 3)
+    #[strum(to_string = "sd1")]
+    Sd1 = 3,
+    /// BOOT_TYPE_SPI_NOR (bit 4)
+    SpiNor = 4,
+    /// BOOT_TYPE_SPI_NAND (bit 5)
+    SpiNand = 5,
+    /// BOOT_TYPE_RAM (bit 6)
+    Ram = 6,
+    /// BOOT_TYPE_MTD_BLK_NAND (bit 7)
     MtdBlkNand = 7,
-    #[strum(to_string = "spi-nand")]
+    /// BOOT_TYPE_MTD_BLK_SPI_NAND (bit 8)
     MtdBlkSpiNand = 8,
-    #[strum(to_string = "spi-nor")]
+    /// BOOT_TYPE_MTD_BLK_SPI_NOR (bit 9)
     MtdBlkSpiNor = 9,
+    /// BOOT_TYPE_SATA (bit 10)
     Sata = 10,
+    /// BOOT_TYPE_PCIE (bit 11)
     Pcie = 11,
+    /// BOOT_TYPE_UFS (bit 12)
+    Ufs = 12,
+    /// Unknown index for future proofing
+    #[num_enum(catch_all)]
+    #[strum(disabled)]
+    Unknown(u8) = 255,
+}
+
+impl StorageIndex {
+    /// All named storage variants (excludes `Unknown`).
+    pub const VARIANTS: &'static [Self] = &[
+        Self::Nand,
+        Self::Emmc,
+        Self::Sd0,
+        Self::Sd1,
+        Self::SpiNor,
+        Self::SpiNand,
+        Self::Ram,
+        Self::MtdBlkNand,
+        Self::MtdBlkSpiNand,
+        Self::MtdBlkSpiNor,
+        Self::Sata,
+        Self::Pcie,
+        Self::Ufs,
+    ];
+}
+
+impl std::fmt::Display for StorageIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown(v) => write!(f, "{v}"),
+            known => f.write_str(<&'static str>::from(known)),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error, Clone)]

--- a/rockusb/src/protocol.rs
+++ b/rockusb/src/protocol.rs
@@ -526,7 +526,7 @@ impl CommandBlock {
         }
     }
 
-    pub fn get_storage() -> CommandBlock {
+    pub fn storage() -> CommandBlock {
         CommandBlock {
             tag: fastrand::u32(..),
             transfer_length: 4,


### PR DESCRIPTION
This PR adds storage get and switch support, which lets you change to another storage type. It is useful when multiple boot devices are present, e.g. eMMC and SPI NOR flash.

Usage example:
```sh
$ ./target/release/examples/rockusb storage
Storage media: emmc
$ ./target/release/examples/rockusb switch-storage spi-nor
Switched storage to spi-nor
```

Possible values: `nand, emmc, sd0, sd1, spi-nor, spi-nand, ram, mtd-blk-nand, mtd-blk-spi-nand, mtd-blk-spi-nor, sata, pcie, ufs`

This corresponds to `rkusb_do_switch_storage` and `rkusb_do_get_storage_info` in https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/usb/gadget/f_rockusb.c

This is a better version of https://github.com/collabora/rockchiprs/pull/42 because users can use storage names rather than numbers.