### PR TITLE
Fix bugs related to seek + buffer causing writing to invalid location

### DIFF
--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -181,6 +181,8 @@ struct DeviceIOInner<D, T> {
     offset: u64,
     size: u64,
     buffer: Box<[u8; 512]>,
+    // The sector that the buffer currently holds data for
+    buffer_sector: u64,
     // Whether or not the buffer is dirty
     state: BufferState,
 }
@@ -206,6 +208,7 @@ where
                 offset: 0,
                 size,
                 buffer: Box::new([0u8; 512]),
+                buffer_sector: 0,
                 state: BufferState::Invalid,
             },
         })
@@ -267,13 +270,16 @@ where
                 len: io_len.min(MAXIO_SIZE) as usize,
             })
         } else {
-            if self.state == BufferState::Invalid {
-                let sector = self.current_sector() as u32;
+            let current_sector = self.current_sector();
+            if self.state == BufferState::Invalid || self.buffer_sector != current_sector {
+                self.flush_buffer().await?;
+                let sector = current_sector as u32;
                 self.device
                     .borrow_mut()
                     .read_lba(sector, self.buffer.as_mut())
                     .await
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))?;
+                self.buffer_sector = current_sector;
                 self.state = BufferState::Valid;
             }
             Ok(IOOperation::Buffered {
@@ -300,7 +306,7 @@ where
 
     async fn flush_buffer(&mut self) -> std::io::Result<()> {
         if self.state == BufferState::Dirty {
-            let sector = self.current_sector() as u32;
+            let sector = self.buffer_sector as u32;
             self.device
                 .borrow_mut()
                 .write_lba(sector, self.buffer.as_mut())
@@ -465,6 +471,7 @@ where
             transport: PhantomData,
             offset: 0,
             buffer: Box::new([0u8; 512]),
+            buffer_sector: 0,
             size,
             state: BufferState::Invalid,
         };

--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -263,6 +263,9 @@ where
         // If the I/O operation is starting at a sector edge and encompasses at least one sector
         // then direct I/O can be done
         if sector_offset == 0 && len >= SECTOR_SIZE {
+            self.flush_buffer().await?;
+            self.state = BufferState::Invalid;
+
             // At most read the amount of bytes left
             let left = self.size - self.offset;
             let io_len = len.min(left) / SECTOR_SIZE * SECTOR_SIZE;


### PR DESCRIPTION
Bug 1 — flush_buffer writes to wrong sector after seek. flush_buffer() used self.current_sector() (derived from self.offset) to determine where to write the dirty buffer. After a seek, offset points to the new position, so the dirty buffer for the old sector would be written to the new sector — corrupting it and losing the old sector's modifications. Fix: Added a buffer_sector field that records which sector the buffer actually holds. flush_buffer now writes to buffer_sector instead of current_sector().

Bug 2 — pre_io uses stale buffer after seek to different sector. pre_io only re-read the sector buffer when state == Invalid. After seeking to a different sector, the state remained Valid/Dirty, so the buffer from the old sector was silently reused for reads and writes at the new position — returning wrong data on reads and mixing sectors on writes. Fix: pre_io now also checks self.buffer_sector != current_sector and flushes + re-reads whenever the sector doesn't match.