### PR TITLE
Add MaybeSend for WASM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ members = [
   "rockusb"
 ]
 
+[patch.crates-io]
+nusb = { git = "https://github.com/jkcoxson/nusb", branch = "webusb" }

--- a/rockusb/.cargo/config.toml
+++ b/rockusb/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = "--cfg=web_sys_unstable_apis"

--- a/rockusb/Cargo.toml
+++ b/rockusb/Cargo.toml
@@ -23,7 +23,7 @@ fastrand = "2"
 num_enum = "0.7"
 thiserror = "2.0.7"
 rusb = { version = "0.9.4", optional = true }
-nusb = { version = "0.1.10", optional = true }
+nusb = { version = "0.2.1", optional = true }
 futures = { version = "0.3.31", optional = true }
 maybe-async-cfg = "0.2.5"
 

--- a/rockusb/Cargo.toml
+++ b/rockusb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rockusb"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 license = "MIT OR Apache-2.0"

--- a/rockusb/README.md
+++ b/rockusb/README.md
@@ -23,10 +23,10 @@ Printing chip info using nusb backend:
 # #[cfg(feature = "nusb")] {
 # #[tokio::main]
 # async fn main() -> anyhow::Result<()> {
-let mut devices = rockusb::nusb::devices()?;
+let mut devices = rockusb::nusb::devices().await?;
 let info = devices.next()
     .ok_or_else(|| anyhow::anyhow!("No Device found"))?;
-let mut device = rockusb::nusb::Device::from_usb_device_info(info)?;
+let mut device = rockusb::nusb::Device::from_usb_device_info(info).await?;
 println!("Chip Info: {:0x?}", device.chip_info().await?);
 Ok(())
 # }

--- a/rockusb/examples/rockusb.rs
+++ b/rockusb/examples/rockusb.rs
@@ -11,7 +11,7 @@ fn list_available_devices() -> Result<()> {
     for d in devices {
         println!(
             "* Bus {} Device {} ID {}:{}",
-            d.bus_number(),
+            d.busnum(),
             d.device_address(),
             d.vendor_id(),
             d.product_id()
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
     let mut devices = rockusb::nusb::devices()?;
     let info = if let Some(dev) = opt.device {
         devices
-            .find(|d| d.bus_number() == dev.bus_number && d.device_address() == dev.address)
+            .find(|d| d.busnum() == dev.bus_number && d.device_address() == dev.address)
             .ok_or_else(|| anyhow!("Specified device not found"))?
     } else {
         let mut devices: Vec<_> = devices.collect();

--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -11,9 +11,12 @@ use crate::{
     protocol::{Capability, ChipInfo, FlashId, FlashInfo, ResetOpcode, SECTOR_SIZE},
 };
 
-#[cfg(feature = "async")]
-use futures::{AsyncRead, AsyncSeek, AsyncWrite, future::BoxFuture, ready};
 use thiserror::Error;
+#[cfg(feature = "async")]
+use {
+    crate::maybe_send::{BoxFuture, MaybeSend},
+    futures::{AsyncRead, AsyncSeek, AsyncWrite, ready},
+};
 
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
 /// Error type return by most [Device] method
@@ -42,10 +45,10 @@ pub trait Transport {
     fn handle_operation<O, T>(
         &mut self,
         operation: O,
-    ) -> impl Future<Output = Result<T, Error<Self::TransportError>>> + Send
+    ) -> impl Future<Output = Result<T, Error<Self::TransportError>>> + MaybeSend
     where
-        O: OperationSteps<T> + Send,
-        T: Send;
+        O: OperationSteps<T> + MaybeSend,
+        T: MaybeSend;
 }
 
 /// Result type return by most [Device] method
@@ -482,7 +485,7 @@ where
 #[cfg(feature = "async")]
 impl<T> AsyncWrite for DeviceIOAsync<DeviceAsync<T>, T>
 where
-    T: TransportAsync + Unpin + Send + 'static,
+    T: TransportAsync + Unpin + MaybeSend + 'static,
 {
     fn poll_write(
         self: std::pin::Pin<&mut Self>,
@@ -555,7 +558,7 @@ where
 #[cfg(feature = "async")]
 impl<T> AsyncRead for DeviceIOAsync<DeviceAsync<T>, T>
 where
-    T: TransportAsync + Unpin + Send + 'static,
+    T: TransportAsync + Unpin + MaybeSend + 'static,
 {
     fn poll_read(
         self: std::pin::Pin<&mut Self>,

--- a/rockusb/src/lib.rs
+++ b/rockusb/src/lib.rs
@@ -6,6 +6,8 @@ pub mod device;
 /// libusb transport implementation
 #[cfg(feature = "libusb")]
 pub mod libusb;
+/// Conditional Send bounds for async code
+pub mod maybe_send;
 /// nusb transport implementation
 #[cfg(feature = "nusb")]
 pub mod nusb;

--- a/rockusb/src/maybe_send.rs
+++ b/rockusb/src/maybe_send.rs
@@ -1,0 +1,18 @@
+#[cfg(not(target_family = "wasm"))]
+mod platform {
+    pub use std::marker::Send as MaybeSend;
+
+    #[cfg(feature = "async")]
+    pub type BoxFuture<'a, T> = futures::future::BoxFuture<'a, T>;
+}
+
+#[cfg(target_family = "wasm")]
+mod platform {
+    pub trait MaybeSend {}
+    impl<T> MaybeSend for T {}
+
+    #[cfg(feature = "async")]
+    pub type BoxFuture<'a, T> = futures::future::LocalBoxFuture<'a, T>;
+}
+
+pub use platform::*;

--- a/rockusb/src/nusb.rs
+++ b/rockusb/src/nusb.rs
@@ -4,7 +4,7 @@ use crate::operation::{OperationSteps, UsbStep};
 pub use nusb::transfer::TransferError;
 use nusb::{
     DeviceInfo,
-    transfer::{Bulk, Buffer, ControlOut, ControlType, In, Out, Recipient},
+    transfer::{Buffer, Bulk, ControlOut, ControlType, In, Out, Recipient},
 };
 use thiserror::Error;
 
@@ -26,7 +26,9 @@ impl DeviceUnavalable {
 
 /// List rockchip devices
 pub async fn devices() -> std::result::Result<impl Iterator<Item = DeviceInfo>, nusb::Error> {
-    Ok(nusb::list_devices().await?.filter(|d| d.vendor_id() == 0x2207))
+    Ok(nusb::list_devices()
+        .await?
+        .filter(|d| d.vendor_id() == 0x2207))
 }
 
 impl From<TransferError> for crate::device::Error<TransferError> {
@@ -137,7 +139,9 @@ impl Device {
     }
 
     /// Create a new transport from an existing device
-    pub async fn from_usb_device(device: nusb::Device) -> std::result::Result<Self, DeviceUnavalable> {
+    pub async fn from_usb_device(
+        device: nusb::Device,
+    ) -> std::result::Result<Self, DeviceUnavalable> {
         for config in device.clone().configurations() {
             for iface_setting in config.interface_alt_settings() {
                 let output = iface_setting.endpoints().find(|e| {
@@ -150,7 +154,9 @@ impl Device {
                 });
 
                 if let (Some(input), Some(output)) = (input, output) {
-                    let interface = device.claim_interface(iface_setting.interface_number()).await?;
+                    let interface = device
+                        .claim_interface(iface_setting.interface_number())
+                        .await?;
                     let ep_in = interface.endpoint::<Bulk, In>(input.address())?;
                     let ep_out = interface.endpoint::<Bulk, Out>(output.address())?;
                     return Ok(Device::new(Transport::new(interface, ep_in, ep_out)));

--- a/rockusb/src/nusb.rs
+++ b/rockusb/src/nusb.rs
@@ -71,7 +71,8 @@ impl crate::device::TransportAsync for Transport {
                     self.ep_in.submit(buf);
                     let completion = self.ep_in.next_complete().await;
                     let result_buf = completion.into_result()?;
-                    data.copy_from_slice(&result_buf[..data.len()]);
+                    let copy_len = data.len().min(result_buf.len());
+                    data[..copy_len].copy_from_slice(&result_buf[..copy_len]);
                 }
                 UsbStep::WriteControl {
                     request_type,

--- a/rockusb/src/nusb.rs
+++ b/rockusb/src/nusb.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use crate::operation::{OperationSteps, UsbStep};
+use crate::{
+    maybe_send::MaybeSend,
+    operation::{OperationSteps, UsbStep},
+};
 pub use nusb::transfer::TransferError;
 use nusb::{
     DeviceInfo,
@@ -51,7 +54,8 @@ impl crate::device::TransportAsync for Transport {
         mut operation: O,
     ) -> crate::device::DeviceResultAsync<T, Self>
     where
-        O: OperationSteps<T>,
+        O: OperationSteps<T> + MaybeSend,
+        T: MaybeSend,
     {
         // Default timeout for USB operations
         const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);


### PR DESCRIPTION
Closed #49 in favor of this - targeting #47  instead of main.

As webusb support seems to be getting closer for nusb (https://github.com/kevinmehall/nusb/pull/199) - I'll mark this as a draft for now as I've patched the `nusb` source to the webusb WIP fork.

With this patch  `cargo check --features nusb --target wasm32-unknown-unknown` succeeds.