### PR TITLE
fix: Correct invalid buffer state after seek 

### DIFF
--- a/rockusb-mock/src/lib.rs
+++ b/rockusb-mock/src/lib.rs
@@ -335,6 +335,10 @@ impl MockState {
         }
         Ok(start..end)
     }
+
+    pub fn flash(&self) -> &[u8] {
+        &self.flash
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -331,8 +331,8 @@ where
         Ok(buf.len())
     }
 
-    fn do_seek(&mut self, pos: SeekFrom) -> u64 {
-        self.offset = match pos {
+    async fn do_seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let new_offset = match pos {
             SeekFrom::Start(offset) => self.size.min(offset),
             SeekFrom::End(offset) => {
                 if offset > 0 {
@@ -352,7 +352,13 @@ where
                 }
             }
         };
-        self.offset
+        let new_sector = new_offset / SECTOR_SIZE;
+        if new_sector != self.current_sector() {
+            self.flush_buffer().await?;
+            self.state = BufferState::Invalid;
+        }
+        self.offset = new_offset;
+        Ok(self.offset)
     }
 
     async fn do_write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
@@ -429,7 +435,7 @@ where
     T: Transport,
 {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        Ok(self.inner.do_seek(pos))
+        self.inner.do_seek(pos)
     }
 }
 
@@ -440,6 +446,7 @@ enum IoState<D, T> {
     Idle(Option<DeviceIOInnerAsync<D, T>>),
     Read(BoxFuture<'static, (DeviceIOInnerAsync<D, T>, ReadResult)>),
     Write(BoxFuture<'static, (DeviceIOInnerAsync<D, T>, std::io::Result<usize>)>),
+    Seek(BoxFuture<'static, (DeviceIOInnerAsync<D, T>, std::io::Result<u64>)>),
     Flush(BoxFuture<'static, (DeviceIOInnerAsync<D, T>, std::io::Result<()>)>),
 }
 
@@ -596,20 +603,35 @@ where
 #[cfg(feature = "async")]
 impl<T> AsyncSeek for DeviceIOAsync<DeviceAsync<T>, T>
 where
-    T: TransportAsync + Unpin,
+    T: TransportAsync + Unpin + Send + 'static,
 {
     fn poll_seek(
         self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
+        cx: &mut std::task::Context<'_>,
         pos: SeekFrom,
     ) -> std::task::Poll<futures::io::Result<u64>> {
         let me = self.get_mut();
-        match me.io_state {
-            IoState::Idle(Some(ref mut inner)) => Poll::Ready(Ok(inner.do_seek(pos))),
-            _ => Poll::Ready(Err(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "Invalid transport state",
-            ))),
+        loop {
+            match me.io_state {
+                IoState::Idle(ref mut inner) => {
+                    let mut inner = inner.take().unwrap();
+                    me.io_state = IoState::Seek(Box::pin(async move {
+                        let r = inner.do_seek(pos).await;
+                        (inner, r)
+                    }));
+                }
+                IoState::Seek(ref mut f) => {
+                    let (inner, r) = ready!(f.as_mut().poll(cx));
+                    me.io_state = IoState::Idle(Some(inner));
+                    return Poll::Ready(r);
+                }
+                _ => {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "Invalid transport state",
+                    )));
+                }
+            }
         }
     }
 }

--- a/rockusb/tests/blockio.rs
+++ b/rockusb/tests/blockio.rs
@@ -1,6 +1,6 @@
 use rockusb::protocol::SECTOR_SIZE;
 use rockusb_mock::{MockDevice, MockDeviceConfig};
-use std::io::Write;
+use std::io::{Seek, SeekFrom, Write};
 
 #[test]
 fn erase_lba() {
@@ -42,5 +42,76 @@ fn simple_linear_write() {
     let flash = mock.flash();
     for (pos, b) in flash.iter().enumerate() {
         assert_eq!((pos & 0xff) as u8, *b, "unexpected value, pos {pos}");
+    }
+}
+
+#[test]
+fn simple_seeking_write() {
+    // Write one byte at a time, each at a prime offset.
+    const PRIME: usize = 97;
+    const SECTORS: usize = 4096;
+
+    fn val_at_pos(pos: usize) -> u8 {
+        // modulo a prime so the sectors aren't all the same;
+        (pos % 13) as u8
+    }
+
+    let flash = (0..SECTORS * SECTOR_SIZE as usize)
+        .map(val_at_pos)
+        .collect();
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash,
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    for i in 0..=(SECTORS * SECTOR_SIZE as usize) / PRIME {
+        io.write_all(&[(i & 0xff) as u8]).unwrap();
+        io.seek(SeekFrom::Current((PRIME - 1) as i64)).unwrap();
+    }
+
+    let flash = mock.flash();
+    for (pos, b) in flash.iter().enumerate() {
+        if pos.is_multiple_of(PRIME) {
+            assert_eq!(
+                ((pos / PRIME) & 0xff) as u8,
+                *b,
+                "unexpected value, pos {pos}"
+            );
+        } else {
+            assert_eq!(val_at_pos(pos), *b, "unexpected change, pos {pos}");
+        }
+    }
+}
+
+#[test]
+fn flush() {
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash: vec![13; 2 * SECTOR_SIZE as usize],
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+
+    // Write just half a sector, this shouldn't be written back
+    io.write_all(&[99; (SECTOR_SIZE / 2) as usize]).unwrap();
+
+    let flash = io.inner().transport().flash();
+    for (pos, b) in flash.iter().enumerate() {
+        assert_eq!(13, *b, "unexpected value, pos {pos}");
+    }
+
+    // Flush, data should now be on storage
+    io.flush().unwrap();
+    let flash = mock.flash();
+    for (pos, b) in flash.iter().enumerate() {
+        let expected = if pos < (SECTOR_SIZE / 2) as usize {
+            99
+        } else {
+            13
+        };
+        assert_eq!(expected, *b, "unexpected value, pos {pos}");
     }
 }

--- a/rockusb/tests/blockio.rs
+++ b/rockusb/tests/blockio.rs
@@ -1,6 +1,12 @@
 use rockusb::protocol::SECTOR_SIZE;
 use rockusb_mock::{MockDevice, MockDeviceConfig};
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
+
+fn byte_at(pos: usize) -> u8 {
+    // Modulo a prime so the pattern doesn't align with sector boundaries,
+    // ensuring each sector has unique content.
+    (pos % 13) as u8
+}
 
 #[test]
 fn erase_lba() {
@@ -48,17 +54,10 @@ fn simple_linear_write() {
 #[test]
 fn simple_seeking_write() {
     // Write one byte at a time, each at a prime offset.
-    const PRIME: usize = 97;
+    const PRIME: usize = 7;
     const SECTORS: usize = 4096;
 
-    fn val_at_pos(pos: usize) -> u8 {
-        // modulo a prime so the sectors aren't all the same;
-        (pos % 13) as u8
-    }
-
-    let flash = (0..SECTORS * SECTOR_SIZE as usize)
-        .map(val_at_pos)
-        .collect();
+    let flash = (0..SECTORS * SECTOR_SIZE as usize).map(byte_at).collect();
     let mut mock = MockDevice::new(MockDeviceConfig {
         flash,
         ..MockDeviceConfig::default()
@@ -80,7 +79,7 @@ fn simple_seeking_write() {
                 "unexpected value, pos {pos}"
             );
         } else {
-            assert_eq!(val_at_pos(pos), *b, "unexpected change, pos {pos}");
+            assert_eq!(byte_at(pos), *b, "unexpected change, pos {pos}");
         }
     }
 }
@@ -114,4 +113,165 @@ fn flush() {
         };
         assert_eq!(expected, *b, "unexpected value, pos {pos}");
     }
+}
+
+#[test]
+fn io_size_matches_flash() {
+    const SECTORS: usize = 4;
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash: vec![0; SECTORS * SECTOR_SIZE as usize],
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let io = device.io().unwrap();
+    assert_eq!(io.size(), SECTORS as u64 * SECTOR_SIZE);
+}
+
+#[test]
+fn simple_linear_read() {
+    const SECTORS: usize = 4;
+    let flash: Vec<u8> = (0..SECTORS * SECTOR_SIZE as usize).map(byte_at).collect();
+    let expected = flash.clone();
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash,
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let buf = {
+        let device = mock.device();
+        let mut io = device.io().unwrap();
+        let mut buf = vec![0u8; SECTORS * SECTOR_SIZE as usize];
+        io.read_exact(&mut buf).unwrap();
+        buf
+    };
+    assert_eq!(buf, expected);
+    assert_eq!(mock.flash(), expected, "read must not modify flash content");
+}
+
+#[test]
+fn read_write_roundtrip() {
+    const SECTORS: usize = 4;
+    let data: Vec<u8> = (0..SECTORS * SECTOR_SIZE as usize).map(byte_at).collect();
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash: vec![0; SECTORS * SECTOR_SIZE as usize],
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    io.write_all(&data).unwrap();
+    io.seek(SeekFrom::Start(0)).unwrap();
+    let mut buf = vec![0u8; SECTORS * SECTOR_SIZE as usize];
+    io.read_exact(&mut buf).unwrap();
+    assert_eq!(buf, data);
+}
+
+#[test]
+fn read_at_eof_returns_zero() {
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash: vec![0; SECTOR_SIZE as usize],
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    io.seek(SeekFrom::End(0)).unwrap();
+    let mut buf = [0u8; 16];
+    assert_eq!(io.read(&mut buf).unwrap(), 0);
+}
+
+#[test]
+fn seek_from_start() {
+    // Step through flash in multiples of a prime. Because the prime is
+    // coprime with SECTOR_SIZE the offsets land at a different position
+    // within each sector on every pass, and each iteration starts from a
+    // different cursor position (offset+1 after the read).
+    const PRIME: usize = 7;
+    const SECTORS: usize = 4;
+    let flash: Vec<u8> = (0..SECTORS * SECTOR_SIZE as usize).map(byte_at).collect();
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash,
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    let mut byte = [0u8; 1];
+
+    for i in 0..SECTORS * SECTOR_SIZE as usize / PRIME {
+        let offset = (i * PRIME) as u64;
+        assert_eq!(io.seek(SeekFrom::Start(offset)).unwrap(), offset);
+        io.read_exact(&mut byte).unwrap();
+        assert_eq!(byte[0], byte_at(offset as usize));
+    }
+}
+
+#[test]
+fn seek_from_end() {
+    // Step back from the end in multiples of a prime for the same reason as
+    // seek_from_start: varied sub-sector positions from varied cursor locations.
+    // Start at i=1 so we skip the trivial seek-to-EOF case.
+    const PRIME: usize = 7;
+    const SECTORS: usize = 4;
+    let size = SECTORS as u64 * SECTOR_SIZE;
+    let flash: Vec<u8> = (0..SECTORS * SECTOR_SIZE as usize).map(byte_at).collect();
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash,
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    let mut byte = [0u8; 1];
+
+    for i in 1..=SECTORS * SECTOR_SIZE as usize / PRIME {
+        let offset = (i * PRIME) as u64;
+        let expected_pos = size - offset;
+        assert_eq!(
+            io.seek(SeekFrom::End(-(offset as i64))).unwrap(),
+            expected_pos
+        );
+        io.read_exact(&mut byte).unwrap();
+        assert_eq!(byte[0], byte_at(expected_pos as usize));
+    }
+}
+
+#[test]
+fn seek_before_start_clamps_to_zero() {
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash: vec![0; 2 * SECTOR_SIZE as usize],
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    assert_eq!(io.seek(SeekFrom::Current(i64::MIN)).unwrap(), 0);
+}
+
+#[test]
+fn seek_past_end_clamps_to_size() {
+    const SECTORS: usize = 2;
+    let size = SECTORS as u64 * SECTOR_SIZE;
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash: vec![0; SECTORS * SECTOR_SIZE as usize],
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    assert_eq!(io.seek(SeekFrom::Start(u64::MAX)).unwrap(), size);
+}
+
+#[test]
+fn write_past_end_returns_error() {
+    let mut mock = MockDevice::new(MockDeviceConfig {
+        flash: vec![0; SECTOR_SIZE as usize],
+        ..MockDeviceConfig::default()
+    })
+    .unwrap();
+    let device = mock.device();
+    let mut io = device.io().unwrap();
+    io.seek(SeekFrom::End(0)).unwrap();
+    assert!(io.write(&[0u8]).is_err());
 }


### PR DESCRIPTION
The DeviceIO buffer assumes the buffer is always for the current buffer.
However when seeking this wasn't taken into account, so when seeking to
a different sector either stale data could be used or incorrect data
written back.
    
Correct this by flushing/invalidating the buffer when seeing to a
different sector.
