### PR TITLE
Use `bus_id()` instead of `busnum()` when constructing/matching on `DeviceArg`

### DIFF
--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -547,17 +547,16 @@ fn reset_parser() -> impl clap::builder::TypedValueParser<Value = ResetOpcode> {
 
 #[derive(Debug, Clone)]
 pub struct DeviceArg {
-    pub bus_number: u8,
+    pub bus_id: String,
     pub address: u8,
 }
 
 fn parse_device(device: &str) -> Result<DeviceArg> {
     let mut parts = device.split(':');
-    let bus_number = parts
+    let bus_id = parts
         .next()
-        .ok_or_else(|| anyhow!("No bus number: use <bus>:<address>"))?
-        .parse()
-        .map_err(|_| anyhow!("Bus should be a number"))?;
+        .ok_or_else(|| anyhow!("No bus id: use <bus>:<address>"))?
+        .to_string();
     let address = parts
         .next()
         .ok_or_else(|| anyhow!("No address: use <bus>:<address>"))?
@@ -567,7 +566,7 @@ fn parse_device(device: &str) -> Result<DeviceArg> {
         return Err(anyhow!("Too many parts"));
     }
     Ok(DeviceArg {
-        bus_number,
+        bus_id,
         address,
     })
 }

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -565,10 +565,7 @@ fn parse_device(device: &str) -> Result<DeviceArg> {
     if parts.next().is_some() {
         return Err(anyhow!("Too many parts"));
     }
-    Ok(DeviceArg {
-        bus_id,
-        address,
-    })
+    Ok(DeviceArg { bus_id, address })
 }
 
 #[derive(clap::Parser)]

--- a/rockusb/examples/rockusb-libusb.rs
+++ b/rockusb/examples/rockusb-libusb.rs
@@ -33,10 +33,12 @@ fn main() -> Result<()> {
             .iter()
             .find(|d| match d {
                 Ok(device) => {
-                    device.bus_number() == dev.bus_number && device.address() == dev.address
+                    let bus_id = format!("{:03}", device.bus_number());
+                    bus_id == dev.bus_id && device.address() == dev.address
                 }
                 Err(DeviceUnavalable { device, .. }) => {
-                    device.bus_number() == dev.bus_number && device.address() == dev.address
+                    let bus_id = format!("{:03}", device.bus_number());
+                    bus_id == dev.bus_id && device.address() == dev.address
                 }
             })
             .ok_or_else(|| anyhow!("Specified device not found"))?

--- a/rockusb/examples/rockusb.rs
+++ b/rockusb/examples/rockusb.rs
@@ -10,8 +10,8 @@ async fn list_available_devices() -> Result<()> {
     println!("Available rockchip devices:");
     for d in devices {
         println!(
-            "* Bus {} Device {} ID {}:{}",
-            d.busnum(),
+            "* Bus {} Device {} ID {:04x}:{:04x}",
+            d.bus_id(),
             d.device_address(),
             d.vendor_id(),
             d.product_id()
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
     let mut devices = rockusb::nusb::devices().await?;
     let info = if let Some(dev) = opt.device {
         devices
-            .find(|d| d.busnum() == dev.bus_number && d.device_address() == dev.address)
+            .find(|d| d.bus_id() == dev.bus_id && d.device_address() == dev.address)
             .ok_or_else(|| anyhow!("Specified device not found"))?
     } else {
         let mut devices: Vec<_> = devices.collect();


### PR DESCRIPTION
`busnum()` is only available on Linux. The cross-platform equivalent is `bus_id()`.

* Linux: String version of the busnum (e.g. "001")
* MacOS: Top byte of the location ID (e.g. "01")
* Windows: Unsure

In any case, it should be consistent with the output of the `list` command  in the example.
