### PR TITLE
fix(rockusb/nusb): Bulk reads should request a length that is a multiple of EP max packet size

### DIFF
--- a/rockusb/src/nusb.rs
+++ b/rockusb/src/nusb.rs
@@ -67,11 +67,14 @@ impl crate::device::TransportAsync for Transport {
                 }
                 UsbStep::ReadBulk { data } => {
                     // For IN transfers, requested_len must be a multiple of max_packet_size
-                    let buf = Buffer::new(data.len());
+                    let max_packet_size = self.ep_in.max_packet_size();
+                    let requested_len = data.len().next_multiple_of(max_packet_size);
+                    let buf = Buffer::new(requested_len);
                     self.ep_in.submit(buf);
                     let completion = self.ep_in.next_complete().await;
                     let result_buf = completion.into_result()?;
-                    data.copy_from_slice(&result_buf);
+                    let copy_len = data.len().min(result_buf.len());
+                    data[..copy_len].copy_from_slice(&result_buf[..copy_len]);
                 }
                 UsbStep::WriteControl {
                     request_type,


### PR DESCRIPTION
This change was present in #47 but seems to have been orphaned in the switch to nusb 0.2.

As per the `nusb` [docs](https://docs.rs/nusb/latest/nusb/struct.Endpoint.html#method.submit):

> For an IN transfer, the buffer’s requested_len is the number of bytes requested. It must be a nonzero multiple of the endpoint’s maximum packet size or the transfer will fail with `TransferError::InvalidArgument`.

Confirmed to be an issue at least on macOS.