### PR TITLE
rockusb: support zstd-compressed images in write-bmap

### DIFF
--- a/rockusb/Cargo.toml
+++ b/rockusb/Cargo.toml
@@ -34,13 +34,14 @@ bmap-parser = "0.2.0"
 clap = { version = "4.2", features = ["derive"] }
 clap-num = "1.0"
 flate2 = "1.0.25"
+zstd = "0.13"
 rockfile = { path = "../rockfile", version = "0.1.2" }
 rockusb-mock = { path = "../rockusb-mock", version = "0.1" }
 rusb = "0.9.1"
 tokio = { version = "1.40.0", features = ["full"] }
 futures = { version = "0.3.31", features = ["compat", "io-compat"]}
 tokio-util = { version = "0.7.12", features = ["compat"] }
-async-compression = { version = "0.4.5", features = ["gzip", "futures-io"] }
+async-compression = { version = "0.4.5", features = ["gzip", "zstd", "futures-io"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -19,9 +19,10 @@ use rockusb::{
     device::{Device, Transport},
     protocol::{ResetOpcode, StorageIndex},
 };
+use zstd::stream::read::Decoder as SyncZstdDecoder;
 
 #[cfg(feature = "async")]
-use async_compression::futures::bufread::GzipDecoder;
+use async_compression::futures::bufread::{GzipDecoder, ZstdDecoder};
 #[cfg(feature = "async")]
 use rockusb::device::{DeviceAsync, TransportAsync};
 #[cfg(feature = "async")]
@@ -284,6 +285,11 @@ where
                 let mut gz = bmap_parser::Discarder::new(gz);
                 bmap_parser::copy(&mut gz, &mut writer, &bmap)?;
             }
+            Some("zst") => {
+                let zstd = SyncZstdDecoder::new(file)?;
+                let mut zstd = bmap_parser::Discarder::new(zstd);
+                bmap_parser::copy(&mut zstd, &mut writer, &bmap)?;
+            }
             _ => {
                 bmap_parser::copy(&mut file, &mut writer, &bmap)?;
             }
@@ -313,6 +319,15 @@ where
                 let gz = GzipDecoder::new(file);
                 let mut gz = bmap_parser::AsyncDiscarder::new(gz);
                 bmap_parser::copy_async(&mut gz, &mut writer, &bmap).await?;
+            }
+            Some("zst") => {
+                let mut zstd = ZstdDecoder::new(file);
+                // Match the sync zstd::Decoder, which decodes all concatenated
+                // frames by default. Without this, a multi-frame image (e.g. from
+                // pzstd) would be silently truncated after the first frame.
+                zstd.multiple_members(true);
+                let mut zstd = bmap_parser::AsyncDiscarder::new(zstd);
+                bmap_parser::copy_async(&mut zstd, &mut writer, &bmap).await?;
             }
             _ => {
                 bmap_parser::copy_async(&mut file, &mut writer, &bmap).await?;


### PR DESCRIPTION
Closes #65.

Add a `.zst` arm to `write-bmap` alongside the existing gzip handling, so compressed images can be flashed without decompressing them first.

The sync (libusb) path uses `zstd::stream::read::Decoder`, which decodes all concatenated frames to EOF by default. The async (nusb) path uses `async_compression`'s `ZstdDecoder`, which defaults to first-frame-only; `multiple_members(true)` is enabled there so multi-frame images (e.g. from `pzstd`) match the sync path and are not silently truncated.

Deps: add `zstd` 0.13 (dev) and the `zstd` feature to `async-compression`.

Tested by flashing a `.zst` image via the libusb backend.