### PR TITLE
Allow disabling CRC checking for maskrom writes

### DIFF
--- a/rockusb/examples/common.rs
+++ b/rockusb/examples/common.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::{Result, anyhow, ensure};
 use bmap_parser::Bmap;
-use clap::builder::TypedValueParser;
+use clap::{ArgAction, builder::TypedValueParser};
 use clap_num::maybe_hex;
 use flate2::read::GzDecoder;
 use rockfile::boot::{
@@ -326,6 +326,7 @@ where
         header: RkBootHeaderEntry,
         code: u16,
         file: &mut File,
+        crc: bool,
     ) -> Result<()> {
         for i in 0..header.count {
             let mut entry: RkBootEntryBytes = [0; 57];
@@ -343,7 +344,11 @@ where
             file.seek(SeekFrom::Start(entry.data_offset as u64))?;
             file.read_exact(&mut data)?;
 
-            self.device.write_maskrom_area(code, &data).await?;
+            if crc {
+                self.device.write_maskrom_area(code, &data).await?;
+            } else {
+                self.device.write_maskrom_area_no_crc(code, &data).await?;
+            }
 
             println!("Done!... waiting {}ms", entry.data_delay);
             if entry.data_delay > 0 {
@@ -354,7 +359,7 @@ where
         Ok(())
     }
 
-    pub async fn download_boot(&mut self, path: &Path) -> Result<()> {
+    pub async fn download_boot(&mut self, path: &Path, crc: bool) -> Result<()> {
         let mut file = File::open(path)?;
         let mut header: RkBootHeaderBytes = [0; 102];
         file.read_exact(&mut header)?;
@@ -362,17 +367,21 @@ where
         let header =
             RkBootHeader::from_bytes(&header).ok_or_else(|| anyhow!("Failed to parse header"))?;
 
-        self.download_entry(header.entry_471, 0x471, &mut file)
+        self.download_entry(header.entry_471, 0x471, &mut file, crc)
             .await?;
-        self.download_entry(header.entry_472, 0x472, &mut file)
+        self.download_entry(header.entry_472, 0x472, &mut file, crc)
             .await?;
 
         Ok(())
     }
 
-    pub async fn download_maskrom_area(&mut self, area: u16, path: &Path) -> Result<()> {
+    pub async fn download_maskrom_area(&mut self, area: u16, path: &Path, crc: bool) -> Result<()> {
         let data = std::fs::read(path)?;
-        self.device.write_maskrom_area(area, &data).await?;
+        if crc {
+            self.device.write_maskrom_area(area, &data).await?;
+        } else {
+            self.device.write_maskrom_area_no_crc(area, &data).await?;
+        }
         Ok(())
     }
 }
@@ -385,14 +394,23 @@ pub enum Command {
     /// Download boot code from a rockfile (maskrom mode)
     #[command(alias = "db")]
     DownloadBoot {
+        /// Disable CRC (May not work on all devices)
+        #[arg(long = "no-crc", action = ArgAction::SetFalse, default_value_t = true)]
+        crc: bool,
         path: PathBuf,
     },
     /// Download code to sram area (maskrom mode)
     DownloadSram {
+        /// Disable CRC (May not work on all devices)
+        #[arg(long = "no-crc", action = ArgAction::SetFalse, default_value_t = true)]
+        crc: bool,
         path: PathBuf,
     },
     /// Download code to DDR area (maskrom mode)
     DownloadDDR {
+        /// Disable CRC (May not work on all devices)
+        #[arg(long = "no-crc", action = ArgAction::SetFalse, default_value_t = true)]
+        crc: bool,
         path: PathBuf,
     },
     #[command(alias = "rl")]
@@ -461,9 +479,13 @@ impl Command {
     {
         match self {
             Command::List => unreachable!(),
-            Command::DownloadSram { path } => device.download_maskrom_area(0x471, &path).await,
-            Command::DownloadDDR { path } => device.download_maskrom_area(0x472, &path).await,
-            Command::DownloadBoot { path } => device.download_boot(&path).await,
+            Command::DownloadSram { crc, path } => {
+                device.download_maskrom_area(0x471, &path, crc).await
+            }
+            Command::DownloadDDR { crc, path } => {
+                device.download_maskrom_area(0x472, &path, crc).await
+            }
+            Command::DownloadBoot { crc, path } => device.download_boot(&path, crc).await,
             Command::Read {
                 offset,
                 length,

--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -153,9 +153,9 @@ where
     /// Write a specific area while in maskrom mode; typically 0x471 or 0x472 data as retrieved from a
     /// rockchip boot file.
     ///
-    /// This variants doesn't set the CRC at the end of the upload, which can provide some speedup
-    /// especially for bigger payloads. This is not supported on all rockchip devices, so may cause
-    /// failed uploads.
+    /// This variant doesn't set the CRC at the end of the upload, which can speed up uploads,
+    /// especially for larger payloads. This is not supported on all Rockchip devices and may cause
+    /// uploads to fail.
     pub async fn write_maskrom_area_no_crc(
         &mut self,
         area: u16,

--- a/rockusb/src/device.rs
+++ b/rockusb/src/device.rs
@@ -150,6 +150,22 @@ where
             .await
     }
 
+    /// Write a specific area while in maskrom mode; typically 0x471 or 0x472 data as retrieved from a
+    /// rockchip boot file.
+    ///
+    /// This variants doesn't set the CRC at the end of the upload, which can provide some speedup
+    /// especially for bigger payloads. This is not supported on all rockchip devices, so may cause
+    /// failed uploads.
+    pub async fn write_maskrom_area_no_crc(
+        &mut self,
+        area: u16,
+        data: &[u8],
+    ) -> DeviceResult<(), T> {
+        self.transport
+            .handle_operation(crate::operation::write_area_no_crc(area, data))
+            .await
+    }
+
     /// Reset the device
     pub async fn reset_device(&mut self, opcode: ResetOpcode) -> DeviceResult<(), T> {
         self.transport

--- a/rockusb/src/operation.rs
+++ b/rockusb/src/operation.rs
@@ -61,7 +61,7 @@ pub trait OperationSteps<T> {
 }
 
 enum MaskRomSteps {
-    Writing(crc::Digest<'static, u16>),
+    Writing(Option<crc::Digest<'static, u16>>),
     Dummy,
     Done,
 }
@@ -83,7 +83,17 @@ impl<'a> MaskRomOperation<'a> {
             block: [0; 4096],
             data,
             area,
-            steps: MaskRomSteps::Writing(CRC.digest()),
+            steps: MaskRomSteps::Writing(Some(CRC.digest())),
+        }
+    }
+
+    fn new_no_crc(area: u16, data: &'a [u8]) -> Self {
+        Self {
+            written: 0,
+            block: [0; 4096],
+            data,
+            area,
+            steps: MaskRomSteps::Writing(None),
         }
     }
 }
@@ -100,20 +110,28 @@ impl OperationSteps<()> for MaskRomOperation<'_> {
                 self.written += chunksize;
                 let chunk = match chunksize {
                     4096 => {
-                        crc.update(&self.block);
+                        if let Some(crc) = crc.as_mut() {
+                            crc.update(&self.block);
+                        }
                         self.steps = MaskRomSteps::Writing(crc);
                         &self.block[..]
                     }
                     4095 => {
                         // Add extra 0 to avoid splitting crc over two blocks
                         self.block[4095] = 0;
-                        crc.update(&self.block);
+                        if let Some(crc) = crc.as_mut() {
+                            crc.update(&self.block);
+                        }
                         self.steps = MaskRomSteps::Writing(crc);
                         &self.block[..]
                     }
                     mut end => {
-                        crc.update(&self.block[0..end]);
-                        let crc = crc.finalize();
+                        let crc = if let Some(mut crc) = crc {
+                            crc.update(&self.block[0..end]);
+                            crc.finalize()
+                        } else {
+                            0
+                        };
                         self.block[end] = (crc >> 8) as u8;
                         self.block[end + 1] = (crc & 0xff) as u8;
                         end += 2;
@@ -154,6 +172,10 @@ impl OperationSteps<()> for MaskRomOperation<'_> {
 /// Write a specific area; typically 0x471 or 0x472 data as retrieved from a rockchip boot file
 pub fn write_area(area: u16, data: &[u8]) -> MaskRomOperation<'_> {
     MaskRomOperation::new(area, data)
+}
+
+pub fn write_area_no_crc(area: u16, data: &[u8]) -> MaskRomOperation<'_> {
+    MaskRomOperation::new_no_crc(area, data)
 }
 
 trait FromOperation {

--- a/rockusb/tests/maskrom.rs
+++ b/rockusb/tests/maskrom.rs
@@ -30,6 +30,20 @@ fn simple_maskrom() {
 }
 
 #[test]
+fn maskrom_no_crc() {
+    let mut mock = MockDevice::default();
+    let device = mock.device();
+
+    device.write_maskrom_area_no_crc(0x471, b"sram").unwrap();
+
+    // sram + crc16
+    let area = mock.maskrom_area(0x471).unwrap();
+    assert_eq!(area.len(), 6);
+    assert_eq!(&area[..4], b"sram");
+    assert_eq!(area[4..6], [0x0, 0x0]);
+}
+
+#[test]
 fn maskrom_4094_byte_payload_adds_dummy_write() {
     let mut mock = MockDevice::default();
     let device = mock.device();

--- a/rockusb/tests/maskrom.rs
+++ b/rockusb/tests/maskrom.rs
@@ -36,7 +36,7 @@ fn maskrom_no_crc() {
 
     device.write_maskrom_area_no_crc(0x471, b"sram").unwrap();
 
-    // sram + crc16
+    // sram + zeroed CRC16 (skip ROM CRC check on supported chips)
     let area = mock.maskrom_area(0x471).unwrap();
     assert_eq!(area.len(), 6);
     assert_eq!(&area[..4], b"sram");


### PR DESCRIPTION
Maskrom writes have a  CRC-16 at the end. The ROM checks this after finishing the write operation, however this can be really slow. Some chips support skipping the check if the CRC is at the end, which can greatly speedup the operation especially when doing a big DDR upload.

Thusfar test show this works on RK3576 (for both sram and DDR), while it's unsupported by RK3308.

Fixes: #66 